### PR TITLE
Turn off zstd

### DIFF
--- a/text_search/Cargo.toml
+++ b/text_search/Cargo.toml
@@ -5,12 +5,15 @@ edition = "2021"
 
 [dependencies]
 cxx = "1.0.111"
-tantivy = "0.21.1"
 log = "0.4.17"
 env_logger = "0.10.0"
 serde_json = "1.0.79"
 # TODO(gitbuda): ahash fixed -> v0.8.7 does NOT compile -> remove below line.
 ahash = "=0.8.5"
+
+[dependencies.tantivy]
+tantivy = "0.21.1"
+default-features = false
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/text_search/Cargo.toml
+++ b/text_search/Cargo.toml
@@ -14,6 +14,7 @@ ahash = "=0.8.5"
 [dependencies.tantivy]
 tantivy = "0.21.1"
 default-features = false
+features = ["mmap"]
 
 [build-dependencies]
 cxx-build = "1.0"


### PR DESCRIPTION
`zstd` symbols heavily interfere with Memgraph’s build process. As zstd is an optional dependency, this PR turns it off.