### PR TITLE
Add get_num_docs function and improve IndexReader usage

### DIFF
--- a/text_search/test_unit.cpp
+++ b/text_search/test_unit.cpp
@@ -18,6 +18,10 @@ TEST(text_search_test_case, simple_test1) {
       });
     }
 
+    // wait for delay to ensure all documents are indexed
+    while (mgcxx::text_search::get_num_docs(context) < 5) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
     mgcxx::text_search::SearchInput search_input = {
         .search_fields = {"metadata"},
         .search_query = "data.key1:AWESOME",
@@ -66,6 +70,10 @@ TEST(text_search_test_case, simple_test2) {
         mgcxx::text_search::add_document(context, doc, false);
         return 0;
       });
+    }
+    // wait for delay to ensure all documents are indexed
+    while (mgcxx::text_search::get_num_docs(context) < 2) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     mgcxx::text_search::SearchInput search_input = {.search_fields = {"gid"},


### PR DESCRIPTION
Added function to retrieve number of documents in the index.
Additionally, improved the usage of IndexReader by ensuring a single reader instance is used for the entire lifetime of the index, while a new searcher is acquired only for each search operation which is the recommended usage pattern in [Tantivy](https://tantivy-search.github.io/examples/basic_search.html).