### PR TITLE
Add relevance score to ouput and add limit option

### DIFF
--- a/text_search/Cargo.lock
+++ b/text_search/Cargo.lock
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "tantivy_text_search"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/text_search/Cargo.toml
+++ b/text_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy_text_search"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 
 [dependencies]

--- a/text_search/src/lib.rs
+++ b/text_search/src/lib.rs
@@ -533,7 +533,6 @@ fn search(
         }
     };
 
-    // Reuse searcher instead of creating it multiple times
     let searcher = reader.searcher();
     let top_docs = match searcher.search(&query, &TopDocs::with_limit(input.effective_limit())) {
         Ok(docs) => docs,
@@ -548,7 +547,6 @@ fn search(
         }
     };
 
-    // Pre-allocate vector with known capacity
     let mut docs: Vec<ffi::DocumentOutput> = Vec::with_capacity(top_docs.len());
     for (score, doc_address) in top_docs {
         let doc: TantivyDocument = match searcher.doc(doc_address) {
@@ -635,7 +633,6 @@ fn regex_search(
         }
     };
 
-    // Reuse searcher instead of creating it multiple times
     let searcher = reader.searcher();
     let top_docs = match searcher.search(&query, &TopDocs::with_limit(input.effective_limit())) {
         Ok(docs) => docs,
@@ -649,7 +646,7 @@ fn regex_search(
             ));
         }
     };
-    // Pre-allocate vector with known capacity
+    
     let mut docs: Vec<ffi::DocumentOutput> = Vec::with_capacity(top_docs.len());
     for (score, doc_address) in top_docs {
         let doc: TantivyDocument = match searcher.doc(doc_address) {

--- a/text_search/src/lib.rs
+++ b/text_search/src/lib.rs
@@ -46,6 +46,7 @@ mod ffi {
     // NOTE: The input struct is/should_be aligned with the schema.
     struct DocumentOutput {
         data: String, // NOTE: Here should probably be Option but it's not supported in cxx.
+        score: f32,   // Relevance score from search
     }
 
     struct SearchInput {
@@ -53,7 +54,8 @@ mod ffi {
         search_query: String,
         return_fields: Vec<String>,
         aggregation_query: String,
-        // TODO(gitbuda): Add stuff like skip & limit.
+        limit: usize,
+        // TODO(gitbuda): Add stuff like skip.
         // NOTE: Any primitive value here is a bit of a problem because of default value on the C++
         // side.
     }
@@ -87,6 +89,12 @@ mod ffi {
         fn aggregate(context: &mut Context, input: &SearchInput) -> Result<DocumentOutput>;
         fn get_num_docs(context: &mut Context) -> Result<u64>;
         fn drop_index(context: Context) -> Result<()>;
+    }
+}
+
+impl ffi::SearchInput {
+    fn effective_limit(&self) -> usize {
+        if self.limit == 0 { 1000 } else { self.limit }
     }
 }
 
@@ -525,7 +533,9 @@ fn search(
         }
     };
 
-    let top_docs = match reader.searcher().search(&query, &TopDocs::with_limit(1000)) {
+    // Reuse searcher instead of creating it multiple times
+    let searcher = reader.searcher();
+    let top_docs = match searcher.search(&query, &TopDocs::with_limit(input.effective_limit())) {
         Ok(docs) => docs,
         Err(e) => {
             return Err(Error::new(
@@ -538,9 +548,10 @@ fn search(
         }
     };
 
-    let mut docs: Vec<ffi::DocumentOutput> = vec![];
-    for (_score, doc_address) in top_docs {
-        let doc: TantivyDocument = match reader.searcher().doc(doc_address) {
+    // Pre-allocate vector with known capacity
+    let mut docs: Vec<ffi::DocumentOutput> = Vec::with_capacity(top_docs.len());
+    for (score, doc_address) in top_docs {
+        let doc: TantivyDocument = match searcher.doc(doc_address) {
             Ok(d) => d,
             Err(e) => {
                 return Err(Error::new(
@@ -594,6 +605,7 @@ fn search(
                     ));
                 }
             },
+            score: score,
         });
     }
     Ok(ffi::SearchOutput { docs })
@@ -623,7 +635,9 @@ fn regex_search(
         }
     };
 
-    let top_docs = match reader.searcher().search(&query, &TopDocs::with_limit(1000)) {
+    // Reuse searcher instead of creating it multiple times
+    let searcher = reader.searcher();
+    let top_docs = match searcher.search(&query, &TopDocs::with_limit(input.effective_limit())) {
         Ok(docs) => docs,
         Err(e) => {
             return Err(Error::new(
@@ -635,9 +649,10 @@ fn regex_search(
             ));
         }
     };
-    let mut docs: Vec<ffi::DocumentOutput> = vec![];
-    for (_score, doc_address) in top_docs {
-        let doc: TantivyDocument = match reader.searcher().doc(doc_address) {
+    // Pre-allocate vector with known capacity
+    let mut docs: Vec<ffi::DocumentOutput> = Vec::with_capacity(top_docs.len());
+    for (score, doc_address) in top_docs {
+        let doc: TantivyDocument = match searcher.doc(doc_address) {
             Ok(d) => d,
             Err(e) => {
                 return Err(Error::new(
@@ -690,6 +705,7 @@ fn regex_search(
                     ));
                 }
             },
+            score: score,
         });
     }
     Ok(ffi::SearchOutput { docs })
@@ -733,6 +749,7 @@ fn aggregate(
     let res: Value = serde_json::to_value(agg_res)?;
     Ok(ffi::DocumentOutput {
         data: res.to_string(),
+        score: 0.0, // Aggregation results don't have individual document scores
     })
 }
 

--- a/text_search/test_bench.cpp
+++ b/text_search/test_bench.cpp
@@ -1,8 +1,5 @@
-#include <iostream>
 #include <memory>
-
 #include <benchmark/benchmark.h>
-
 #include "test_util.hpp"
 
 // cnt is here to ensure unique directory names because gbench is running

--- a/text_search/test_unit.cpp
+++ b/text_search/test_unit.cpp
@@ -127,7 +127,6 @@ TEST(text_search_test_case, limit_test) {
     for (const auto &doc : dummy_data1(10, 10)) {
       mgcxx::text_search::add_document(context, doc, false);
     }
-
     // wait for all documents to be indexed
     while (mgcxx::text_search::get_num_docs(context) < 10) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -141,20 +140,18 @@ TEST(text_search_test_case, limit_test) {
         .limit = 3};
     auto result_limit3 = mgcxx::text_search::search(context, search_input_limit3);
     ASSERT_EQ(result_limit3.docs.size(), 3);
-    
-    // Verify that scores are being returned and are valid
     for (const auto& doc : result_limit3.docs) {
       ASSERT_GT(doc.score, 0.0f); // Scores should be positive
     }
 
     mgcxx::text_search::SearchInput regex_search_input = {
-        .search_fields = {"metadata"},
-        .search_query = "AW*",
+        .search_fields = {"data"},
+        .search_query = ".*",
         .return_fields = {"data"},
         .aggregation_query = "",
         .limit = 2};
     auto regex_result = mgcxx::text_search::regex_search(context, regex_search_input);
-    ASSERT_GE(regex_result.docs.size(), 0);
+    ASSERT_EQ(regex_result.docs.size(), 2);
 
     mgcxx::text_search::drop_index(std::move(context));
   } catch (const ::rust::Error &error) {

--- a/text_search/test_unit.cpp
+++ b/text_search/test_unit.cpp
@@ -1,6 +1,5 @@
 #include "gtest/gtest.h"
 #include <thread>
-#include <chrono>
 
 #include "test_util.hpp"
 

--- a/text_search/test_unit.cpp
+++ b/text_search/test_unit.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include <thread>
+#include <chrono>
 
 #include "test_util.hpp"
 
@@ -112,6 +113,53 @@ TEST(text_search_test_case, mappings) {
     std::cout << error.what() << std::endl;
     EXPECT_STREQ(error.what(), "The field does not exist: 'data' inside "
                                "\"tantivy_index_mappings\" text search index");
+  }
+}
+
+TEST(text_search_test_case, limit_test) {
+  try {
+    auto index_name = fmt::format("tantivy_index_limit_test_{}", 
+                                  std::chrono::duration_cast<std::chrono::microseconds>(
+                                    std::chrono::high_resolution_clock::now().time_since_epoch()).count());
+    auto index_config =
+        mgcxx::text_search::IndexConfig{.mappings = dummy_mappings1().dump()};
+    auto context = mgcxx::text_search::create_index(index_name, index_config);
+
+    for (const auto &doc : dummy_data1(10, 10)) {
+      mgcxx::text_search::add_document(context, doc, false);
+    }
+
+    // wait for all documents to be indexed
+    while (mgcxx::text_search::get_num_docs(context) < 10) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    mgcxx::text_search::SearchInput search_input_limit3 = {
+        .search_fields = {"metadata"},
+        .search_query = "data.key1:AWESOME",
+        .return_fields = {"data"},
+        .aggregation_query = "",
+        .limit = 3};
+    auto result_limit3 = mgcxx::text_search::search(context, search_input_limit3);
+    ASSERT_EQ(result_limit3.docs.size(), 3);
+    
+    // Verify that scores are being returned and are valid
+    for (const auto& doc : result_limit3.docs) {
+      ASSERT_GT(doc.score, 0.0f); // Scores should be positive
+    }
+
+    mgcxx::text_search::SearchInput regex_search_input = {
+        .search_fields = {"metadata"},
+        .search_query = "AW*",
+        .return_fields = {"data"},
+        .aggregation_query = "",
+        .limit = 2};
+    auto regex_result = mgcxx::text_search::regex_search(context, regex_search_input);
+    ASSERT_GE(regex_result.docs.size(), 0);
+
+    mgcxx::text_search::drop_index(std::move(context));
+  } catch (const ::rust::Error &error) {
+    FAIL() << "Test failed: " << error.what();
   }
 }
 


### PR DESCRIPTION
This PR enhances the text search functionality by adding a configurable limit parameter to search queries (with default fallback to 1000) and includes relevance scores in search results. 